### PR TITLE
Nav root reset

### DIFF
--- a/quintagroup/dropdownmenu/browser/menu.py
+++ b/quintagroup/dropdownmenu/browser/menu.py
@@ -21,10 +21,11 @@ class DropDownMenuQueryBuilder(SitemapQueryBuilder):
         self.context = context
 
         # basing query path on navigation root
-        portal = api.portal.get()
-        navRoot = api.portal.getNavigationRootObject(context, portal)
-        navRootPath = '/'.join(navRoot.getPhysicalPath())
-        self.query['path']['query'] = navRootPath
+        if self._settings.navRootResets:
+            portal = api.portal.get()
+            navRoot = api.portal.getNavigationRootObject(context, portal)
+            navRootPath = '/'.join(navRoot.getPhysicalPath())
+            self.query['path']['query'] = navRootPath
 
         # customize depth according to dropdown menu settings
         if self._settings.content_tabs_level > 0:

--- a/quintagroup/dropdownmenu/browser/menu.py
+++ b/quintagroup/dropdownmenu/browser/menu.py
@@ -4,6 +4,8 @@ from zope.interface import implements
 from Products.CMFPlone.browser.navtree import SitemapQueryBuilder
 from Products.CMFPlone.browser.navtree import DefaultNavtreeStrategy
 
+from plone import api
+
 from plone.app.layout.navigation.interfaces import INavtreeStrategy
 from plone.app.layout.navigation.interfaces import INavigationQueryBuilder
 
@@ -17,6 +19,12 @@ class DropDownMenuQueryBuilder(SitemapQueryBuilder):
     def __init__(self, context):
         super(DropDownMenuQueryBuilder, self).__init__(context)
         self.context = context
+
+        # basing query path on navigation root
+        portal = api.portal.get()
+        navRoot = api.portal.getNavigationRootObject(context, portal)
+        navRootPath = '/'.join(navRoot.getPhysicalPath())
+        self.query['path']['query'] = navRootPath
 
         # customize depth according to dropdown menu settings
         if self._settings.content_tabs_level > 0:

--- a/quintagroup/dropdownmenu/browser/templates/sections_recurse.pt
+++ b/quintagroup/dropdownmenu/browser/templates/sections_recurse.pt
@@ -6,9 +6,11 @@
         ><tal:navitem repeat="node children"
             ><li tal:define="is_current      node/currentItem;
                              is_in_path      node/currentParent;
+                             is_anon         context/@@plone_portal_state/anonymous;
                              li_id           string:portaltab-${node/id}-level$level;
                              item_url        node/getURL;
                              item_remote_url node/getRemoteUrl|nothing;
+                             item_remote_url python: (item_remote_url and is_anon) and item_remote_url.replace('manageweb.ict.','www.') or item_remote_url;
                              link_remote     node/link_remote|nothing;
                              item_url        python:link_remote and item_remote_url or item_url;
                              li_curr_class   python:is_current and 'selected' or '';

--- a/quintagroup/dropdownmenu/browser/templates/sections_recurse.pt
+++ b/quintagroup/dropdownmenu/browser/templates/sections_recurse.pt
@@ -9,10 +9,6 @@
                              is_anon         context/@@plone_portal_state/anonymous;
                              li_id           string:portaltab-${node/id}-level$level;
                              item_url        node/getURL;
-                             item_remote_url node/getRemoteUrl|nothing;
-                             item_remote_url python: (item_remote_url and is_anon) and item_remote_url.replace('manageweb.ict.','www.') or item_remote_url;
-                             link_remote     node/link_remote|nothing;
-                             item_url        python:link_remote and item_remote_url or item_url;
                              li_curr_class   python:is_current and 'selected' or '';
                              li_extr_class   python:(is_in_path and not is_current) and 'selected' or '';
                              li_extr_class   python:(not (is_in_path or is_current)) and li_extr_class + 'plain' or li_extr_class;

--- a/quintagroup/dropdownmenu/interfaces.py
+++ b/quintagroup/dropdownmenu/interfaces.py
@@ -104,6 +104,6 @@ class IDropDownMenuSettings(Interface):
 
     navRootResets = schema.Bool(
         title=_(u"Resets menu to the near Navigation Root"),
-        description=_(u"Use select tag if the menu should be build according to \
+        description=_(u"Use select tag if the menu should be built according to \
         the near ancestor who implements INavigationRoot (sub-sites)"),
         default=False)

--- a/quintagroup/dropdownmenu/interfaces.py
+++ b/quintagroup/dropdownmenu/interfaces.py
@@ -101,3 +101,9 @@ class IDropDownMenuSettings(Interface):
         title=_(u"Display menu as select for small screens"),
         description=_(u"Use select tag to display menu for small screens"),
         default=False)
+
+    navRootResets = schema.Bool(
+        title=_(u"Resets menu to the near Navigation Root"),
+        description=_(u"Use select tag if the menu should be build according to \
+        the near ancestor who implements INavigationRoot (sub-sites)"),
+        default=False)

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(name='quintagroup.dropdownmenu',
       install_requires=[
           'setuptools',
           'plone.registry',
+          'plone.api',
           'plone.app.registry',
       ],
       tests_require=tests_require,


### PR DESCRIPTION
Sometimes you have subsections that implement INavigationRoot. Portal's behavior in this case is resetting the portal root in a couple of case: navigation tree, breadcrumbs, etc.

Perhaps is useful to choose to apply this at dropdown menu too (default False)